### PR TITLE
Wi-Fi issues only in X% of the visited hackathons (controlled via const)

### DIFF
--- a/js/constants.js
+++ b/js/constants.js
@@ -8,3 +8,6 @@ var ITEM_OBJECTS = [];
 var ITEM_SPAWN_DELAY = 1000;
 
 var WIFI_VIEW_COLLECTED = 5;
+
+// as a float between 0.0 and 1.0
+var PROBABILITY_OF_WIFI_ISSUES_ON_A_HACKATHON = 0.2;

--- a/js/game.js
+++ b/js/game.js
@@ -228,11 +228,8 @@ var p2xp = 0;
                 var autoDestruct = createAutoDestructTimer(item, 3)
             }
 
-            // B takes you to the wifi level immediately
             var specialKey = game.input.keyboard.addKey(Phaser.Keyboard.B);
-            specialKey.onDown.addOnce(function () {
-                game.state.start('special');
-            }, this);
+            specialKey.onDown.addOnce(this.start, this);
         },
         update: function () {
             //  Collide the player and the items with the platforms

--- a/js/game.js
+++ b/js/game.js
@@ -228,8 +228,11 @@ var p2xp = 0;
                 var autoDestruct = createAutoDestructTimer(item, 3)
             }
 
+            // B takes you to the wifi level immediately
             var specialKey = game.input.keyboard.addKey(Phaser.Keyboard.B);
-            specialKey.onDown.addOnce(this.start, this);
+            specialKey.onDown.addOnce(function () {
+                game.state.start('special');
+            }, this);
         },
         update: function () {
             //  Collide the player and the items with the platforms
@@ -291,11 +294,16 @@ var p2xp = 0;
                 player_object.sprite.scale.setTo(item_object.effect.dScale * PLAYER_DEFAULT_SCALE, item_object.effect.dScale * PLAYER_DEFAULT_SCALE)
                 objectSprite.kill();
 
+                // handle hackathons, which may result in a spawn in no-wifi room
                 if (item_object.name == 'mlh') {
                     p1xp = p1.xp.getXP();
                     p2xp = p2.xp.getXP();
 
-                    game.state.start('special');
+                    // sometimes the wifi doesn't work on the hackathon
+                    var rndHack = game.rnd.integerInRange(0, 100);
+                    if (rndHack < PROBABILITY_OF_WIFI_ISSUES_ON_A_HACKATHON * 100) {
+                        game.state.start('special');
+                    }
                 }
             }
 


### PR DESCRIPTION
The Wi-Fi level was appearing annoyingly often, so I've added the concept of wifi issues only happening in a proportion of the visited hackathons.. Set it to 20% now, so 1 in 5 of the hackathons will have wifi issues (statistically speaking).