### PR TITLE
Fix for the cheat (B key) for exiting the Wi-Fi room

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -228,8 +228,11 @@ var p2xp = 0;
                 var autoDestruct = createAutoDestructTimer(item, 3)
             }
 
+            // B takes you to the wifi level immediately
             var specialKey = game.input.keyboard.addKey(Phaser.Keyboard.B);
-            specialKey.onDown.addOnce(this.start, this);
+            specialKey.onDown.addOnce(function () {
+                game.state.start('special');
+            }, this);
         },
         update: function () {
             //  Collide the player and the items with the platforms
@@ -304,11 +307,6 @@ var p2xp = 0;
                 }
             }
 
-        },
-
-        start: function () {
-            game.state.start('special');
-            console.log('special');
         }
     };
 
@@ -424,8 +422,11 @@ var p2xp = 0;
                 createAutoDestructTimer(item, 2)
             }
 
+            // here in wifi level, B takes you back to the general one
             var specialKey = game.input.keyboard.addKey(Phaser.Keyboard.B);
-            specialKey.onDown.addOnce(this.start, this);
+            specialKey.onDown.addOnce(function () {
+                game.state.start('game');
+            }, this);
         },
         update: function () {
             //  Collide the player and the items with the platforms
@@ -453,11 +454,6 @@ var p2xp = 0;
                 }
             }
 
-        },
-
-        start: function () {
-            game.state.start('special');
-            console.log('special');
         }
     };
 


### PR DESCRIPTION
There is a bug that prevents the `B` cheat key to be used to exit the Wi-Fi room.. That's why during the demos I had to go and chase 5 Wi-Fis every time :D Here's a fix and a bit of a cleanup.

We've had the `B` key mapped for spawning into the Wi-Fi room - that worked fine. 